### PR TITLE
added coffeeBot, /coffee feature now available

### DIFF
--- a/Modules/CoffeeBot.py
+++ b/Modules/CoffeeBot.py
@@ -1,0 +1,39 @@
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import Updater, CommandHandler, CallbackQueryHandler
+from constants.members import getName, getTOP
+from RandomText import get_random_coffee_starter, get_random_coffee_end
+
+
+def sendCoffeeInvitation(bot, update):
+    userid = update.message.from_user.id
+    name = getName(userid)
+    top = getTOP(userid)
+
+    keyboard = [
+        [InlineKeyboardButton("TOP {}".format(top), callback_data=str("host")),
+        InlineKeyboardButton("wo anders", callback_data=str("other")),
+        InlineKeyboardButton("FH", callback_data=str("FH"))]
+    ]
+    replyMarkup = InlineKeyboardMarkup(keyboard)
+
+    firstText = get_random_coffee_starter().replace("$", name)
+    update.message.reply_text(firstText, reply_markup=replyMarkup)
+
+
+def sendCoffeeSticker(bot, update):
+    #chatid = update.message.chat.id
+    pass
+
+
+def sendCoffeeLocation(bot, update):
+    query = update.callback_query
+    userid = query.from_user.id
+    text = query.message.text
+    text += "\n\n"
+
+    end = get_random_coffee_end(query.data)
+    if query.data == "host":
+        end = end.replace("$", str(getTOP(userid)))
+    text += end
+
+    query.edit_message_text(text=text)

--- a/RandomText.py
+++ b/RandomText.py
@@ -79,6 +79,45 @@ def get_random_free_text() -> str:
         "Schenan FH-freien tog wünsch i eich."
     ])
 
+def get_random_coffee_starter() -> str:
+    return get_random_string([
+        "En $ gustats nach am Kaffee!",
+        "$ hätte Appettit auf ein koffeeinhaltiges Heißgetränk.",
+        "Zahts wen Kaffee? $ frogat.",
+        "Die Bohnen rufen! Frogts en $, dea hods a ghead!",
+        "Covfefe! ☕",
+        "Er wärmt von innen, er wärmt von außen, er sozialisiert alle Studenten da draußen. $ dad a Kaffee zahn!",
+        "☕? $ frogt."
+    ])
+
+ends = {
+    "host": 
+        ["Wie wads mid TOP $?",
+        "Treff ma uns in TOP $?",
+        "Er gabat an aus in TOP $.",
+        "Hört hört, der Veranstaltungsort beläuft sich auf TOP № $.",
+        "Irgendwie ziagts mi zu $.",
+        '''Heads ia des? I glaub es is Halloween. Do hea i a paar Geister rufen, "Kuuuuumds zu $!". Es a?''',
+        "I glaub d'Kaffeemaschin' in TOP $ rennd scho.",
+        "De Kaffeemaschin' aus TOP $ hea i bis do auffa, i glaub do gibts boid an.",
+        "Trompeter bitte indn Partyraum. Kaffeetrinker bitte in TOP $."],
+    "other":
+        ["Gibts in dem Haus irgendwo Kaffeemaschinen?",
+        "Zahts wen hosten?",
+        "GET /coffeeLocation.html HTTP/1.1\nServer: Du?",
+        "Wo soin ma?",
+        "Hod wea an Kaffee fia de armen Studenten?"],
+    "FH":
+        ["Ob en Julian sei Chip nu wos draufhat?",
+        "Hod da Julian zufällig sein Chip aufgladn?",
+        "Wo is do da nächste Automat in da FH?",
+        "Man lasset die FH-Plastikbecher klingen.",
+        "A irish coffee in da FH wad a wos. Is do eig Rum drin?"
+        ]
+}
+def get_random_coffee_end(type) -> str:
+    return get_random_string(ends[type])
+
 
 def get_random_string(l: [str]) -> str:
     return l[random.randint(0, len(l)-1)]

--- a/constants/members.py
+++ b/constants/members.py
@@ -1,0 +1,25 @@
+users = dict([
+    (46535653, {"name": "Thomas", "top": 13}),
+    (225652477, {"name": "Philipp", "top": 9}),
+    (431332931, {"name": "Stephan", "top": 3}),
+    (10243457, {"name": "Alexander", "top": 9}),
+    (416387342, {"name": "Julian", "top": 14}),
+    (491884854, {"name": "Tobias", "top": 9}),
+    (495226626, {"name": "Daniel", "top": 3})
+])
+
+
+def getTOP(userid):
+    try:
+        top = users[userid]["top"]
+        return top
+    except KeyError:
+        return "7 (pls no)"
+
+
+def getName(userid):
+    try:
+        name = users[userid]["name"]
+        return name
+    except KeyError:
+        return "Markus (pls no)"

--- a/heinzBot.py
+++ b/heinzBot.py
@@ -6,7 +6,7 @@ import random
 import inspect
 
 from telegram import ChatAction, InlineQueryResultArticle, InputTextMessageContent, Sticker
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, InlineQueryHandler
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, InlineQueryHandler, CallbackQueryHandler
 from CalenderRead import send_first_appointment_of_day, setup_day_ended
 from RandomText import get_random_ask_answer, get_random_quote_text, get_random_free_text
 from GoogleSearch import get_image, get_gif, get_youtube
@@ -22,6 +22,8 @@ from RedditBot import send_funny_submission, send_subreddit_submission
 from CommicBot import receive_comic, send_comic_if_new
 from MittagBot import receive_menue
 from Modules.LetMeGoogleBot import create_google_request
+from Modules.CoffeeBot import sendCoffeeInvitation, sendCoffeeLocation
+from constants.members import getTOP, getName
 
 import requests
 import logging
@@ -83,6 +85,13 @@ def google(bot, update):
     if not (has_rights(update)):
         return
     create_google_request(bot, update)
+
+
+# CoffeeBot
+def coffee(bot, update):
+    if not (has_rights(update)):
+        return
+    sendCoffeeInvitation(bot, update)
 
 
 @send_photo_action
@@ -239,6 +248,8 @@ def main():
     dp.add_handler(CommandHandler('google', google))
     dp.add_handler(CommandHandler('ya', google))
     dp.add_handler(CommandHandler('ddg', google))
+    dp.add_handler(CommandHandler("coffee", coffee))
+    dp.add_handler(CallbackQueryHandler(sendCoffeeLocation))
 
     #read_config()
 
@@ -347,6 +358,7 @@ def help(bot, update):
 /reddit - Wennsd an subreddit angibst schick i da ans vo die top 30 hot bilder oder videos. 😎 als 2. parameter kanns an index angeben.
 /funny - i schick da funny reddit submissions. 👌
 /moizeit - Wos heid in Hagenberg zum fuadan gibt
+/coffee - lädt zu einem Kaffee ein. ☕
 /start - Bot starten (Täglicher Vorlesungs-Reminder)"""
     if not (has_rights(update)):
         return


### PR DESCRIPTION
/coffee lädt andere Teichhausbewohner zu am Kaffee ins eigene TOP, a andere Wohnung oda in da FH ein. Dazu kann der sendende User über's inline keyboard (new, fancy, shiny!) auswählen wo ma trinken sollen, und Heinz schreibt's dann ind Nachricht.
Heinz lernt dazu a paar neue lässige (interaktive!) Sprüche, de zu RandomText.py hinzugefügt werden. 
Sticker is nu WIP. Außerdem soll a deeplink für teilnehmen nu dazua kommen.
constants/members.py hat a Liste von Teichhausmembers, mit deren user IDs, Namen und TOP. Funktionen san wiederverwendbar für zukünftige Features. 
