### PR TITLE
[TASK] Working modules after refactor

### DIFF
--- a/modules/default_module.py
+++ b/modules/default_module.py
@@ -5,22 +5,19 @@ from telegram import Update
 from telegram.ext import CommandHandler, CallbackContext, Dispatcher
 
 from sending_actions import send_photo_action
-from utils.decorators import register
+from utils.decorators import register_command, register_module
 
 
+@register_module(active=True, key="DefaultModule")
 class DefaultModule:
     mutedAccounts = list()
     __commandList = ""
     keyFileName = "api-keys.json"
 
-    # Call this in your module to register your commands
-    def add_command(self, dp):
-        pass
-
     def add_help_text(self, text):
         DefaultModule.__commandList += text
 
-    @register(command="help", text="/help Show this help message. \n")
+    @register_command(command="help", text="/help Show this help message. \n")
     def help(self, update: Update, context: CallbackContext):
         chat_id = self.get_chat_id(update)
         context.bot.send_message(chat_id=chat_id, text=self.__commandList)
@@ -29,7 +26,7 @@ class DefaultModule:
         return update.message.chat_id
 
     # In Version 12 of the telegram bot some major changes were made.
-    @register(command="default", text="/default Show a default message. \n")
+    @register_command(command="default", text="/default Show a default message. \n")
     def default_command(self, update: Update, context: CallbackContext):
         # Get the new job handler
         job = context.job
@@ -65,7 +62,7 @@ class DefaultModule:
             print(key_name + " not found")
             return ""
 
-    @register(command="mute", text="/mute $user Mute a user")
+    @register_command(command="mute", text="/mute $user Mute a user")
     def mute(self, update: Update, context: CallbackContext):
         if update.message.from_user.username == "jajules":
             person = update.message.text.replace('/mute ', '')

--- a/modules/let_me_google_bot.py
+++ b/modules/let_me_google_bot.py
@@ -7,11 +7,12 @@ from telegram.ext import CommandHandler
 from modules.default_module import DefaultModule
 
 from api_key_reader import read_key
-from utils.decorators import register
+from utils.decorators import register_command, register_module
 
 base_url = "https://de.lmgtfy.com/"
 
 
+@register_module(active=False, key="Module")
 class LetMeGoogleBot(DefaultModule):
 
     def add_command(self, dp):
@@ -26,10 +27,10 @@ class LetMeGoogleBot(DefaultModule):
         DefaultModule.commandList += "/ya $term Yahoos the term for you via the 'Let me google that for you API' \n"
         DefaultModule.commandList += "/ddg $term DuckDuckGoes the term for you via the 'Let me google that for you API' \n"
 
-    @register(command="google",
-              text="/google $term Googles the term for you via the 'Let me google that for you API' \n")
-    @register(command="ya",
-              text="/ya $term Yahoos the term for you via the 'Let me google that for you API' \n")
+    @register_command(command="google",
+                      text="/google $term Googles the term for you via the 'Let me google that for you API' \n")
+    @register_command(command="ya",
+                      text="/ya $term Yahoos the term for you via the 'Let me google that for you API' \n")
     def create_google_request(self, bot, update):
         if not self.has_rights(update):
             return

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,7 +1,16 @@
-def register(command, text):
+def register_command(command, text):
     def register_wrapper(func):
         func._command = command
         func._text = text
         return func
+
+    return register_wrapper
+
+
+def register_module(active: bool, key: str):
+    def register_wrapper(clazz):
+        clazz._active = active
+        clazz._key = key
+        return clazz
 
     return register_wrapper


### PR DESCRIPTION
## Added Decorator to Classes
- This makes it possible to ditch the config.json and handle active modules directly via the decorator.
<details>

![image](https://user-images.githubusercontent.com/10941954/77235871-d8e17f00-6bb9-11ea-8370-d51ada97c48e.png)

</details>

### Problems
- Right now the sub modules that inherit from the Def.Module are automatically calling the decorator this may be fixed, which would make it possible to get rid of the key in the decorator.

## Modules
- loading the modules also works dynamically

<details>

``` python
def load_module(name, dp):
    # [:-3] in order to remove the .py ending
    name = name[:-3]
    path = "modules." + name
    imported = __import__(name=path)
    module = getattr(imported, name)

    # Load all classes inside a module
    classes = inspect.getmembers(module, inspect.isclass)
    clazz_name = None

    # pick the class that is inside the module and not imported
    for (name, clazz) in classes:
        if clazz.__module__ == path:
            clazz_name = name
            break
    if clazz_name is None:
        return

        # create class instance
    clazz = getattr(module, clazz_name)
    if hasattr(clazz, "_active") and hasattr(clazz, "_key"):
        if clazz._active is not True or clazz._key != clazz_name:
            return
    else:
        return

    inst = clazz()
    methods = inspect.getmembers(inst, predicate=inspect.ismethod)
    for (key, method) in methods:
        if hasattr(method, "_command") and hasattr(method, "_text"):
            dp.add_handler(CommandHandler(method._command, method))
            help_text_func = getattr(inst, "add_help_text")
            help_text_func(method._text)
```

</details>


